### PR TITLE
Switch CI to use misterraindrop1/test mirrored Docker images

### DIFF
--- a/scripts/mirror-test-images.sh
+++ b/scripts/mirror-test-images.sh
@@ -32,7 +32,10 @@
 set -euo pipefail
 
 SRC_NS=pgbackrest/test
-DST_NS=pgbunker/test
+# Mirror destination. Currently the maintainer's personal Docker Hub repo, since
+# Docker Hub no longer offers free organization creation. If pgBunker ever moves
+# to a paid 'pgbunker' org, switch this back to 'pgbunker/test'.
+DST_NS=misterraindrop1/test
 DRY_RUN=${1:-}
 
 # (vm:arch:date) tuples taken from test/container.yaml. Keep in sync as new VMs are
@@ -102,12 +105,11 @@ echo
 echo "Done. ${#TAGS[@]} images mirrored to ${DST_NS}."
 echo
 echo "Next steps:"
-echo "  1. Verify the images are visible at https://hub.docker.com/r/pgbunker/test/tags"
-echo "  2. Switch the test harness back to using the project namespace dynamically:"
+echo "  1. Verify the images are visible at https://hub.docker.com/r/${DST_NS}/tags"
+echo "  2. Confirm the test harness already points at this namespace:"
 echo
 echo "       test/lib/pgBunkerTest/Common/ContainerTest.pm  (sub containerRepo)"
 echo "       test/src/common/harnessHost.c                  (image strNewFmt)"
 echo
-echo "     Both currently hardcode 'pgbackrest/test'. Revert to using PROJECT_EXE so"
-echo "     the harness composes 'pgbunker/test' from the binary name."
+echo "     Both should reference '${DST_NS}'."
 echo "  3. Push and watch CI - the next run should pull from your mirrored namespace."

--- a/test/lib/pgBunkerTest/Common/ContainerTest.pm
+++ b/test/lib/pgBunkerTest/Common/ContainerTest.pm
@@ -52,9 +52,10 @@ my $hContainerCache;
 ####################################################################################################################################
 sub containerRepo
 {
-    # The pgBackRest upstream maintains a 'pgbackrest/test' Docker Hub namespace with the base/test images that the test harness
-    # builds on top of. pgBunker has not published its own test image set yet, so VM-based tests reuse the upstream images.
-    return 'pgbackrest/test';
+    # pgBunker's mirror of the upstream pgBackRest test base images, maintained at docker.io/misterraindrop1/test (see
+    # scripts/mirror-test-images.sh). Hardcoded here rather than composed from PROJECT_EXE because Docker Hub does not offer
+    # free organization creation, so we use the maintainer's personal namespace until a paid 'pgbunker' org is set up.
+    return 'misterraindrop1/test';
 }
 
 push @EXPORT, qw(containerRepo);

--- a/test/src/common/harnessHost.c
+++ b/test/src/common/harnessHost.c
@@ -1234,8 +1234,9 @@ hrnHostBuild(const int line, const HrnHostTestDefine *const testMatrix, const si
         testDef->repo, testDef->tls, testDef->stg, testDef->enc, testDef->cmp, testDef->rt, testDef->bnd, testDef->bi,
         hrnHostLocal.nonVersionSpecific);
 
-    // Create pg hosts. Use upstream pgbackrest/test images - pgBunker does not publish its own Docker test image set yet.
-    const String *const image = strNewFmt("pgbackrest/test:%s-test-%s", testVm(), testArchitecture());
+    // Create pg hosts. Tag namespace must match ContainerTest.pm::containerRepo (currently misterraindrop1/test - see
+    // scripts/mirror-test-images.sh for why pgBunker uses a personal Docker Hub namespace).
+    const String *const image = strNewFmt("misterraindrop1/test:%s-test-%s", testVm(), testArchitecture());
 
     hrnHostBuildRun(line, HRN_HOST_PG1, image);
     HrnHost *const pg2 = hrnHostBuildRun(line, HRN_HOST_PG2, image);

--- a/test/test.pl
+++ b/test/test.pl
@@ -569,6 +569,7 @@ eval
                 $strFile eq 'doc/release.pl' ||
                 $strFile eq 'test/ci.pl' ||
                 $strFile eq 'test/test.pl' ||
+                $strFile eq 'scripts/mirror-test-images.sh' ||
                 $hManifest->{$strFile}{type} eq 'd')
             {
                 $strExpectedMode = sprintf('%04o', oct($hManifest->{$strFile}{mode}) & 0777);


### PR DESCRIPTION
## Summary

  - Mirrored 8 Docker test base images from upstream `pgbackrest/test` to
    `misterraindrop1/test` via `scripts/mirror-test-images.sh` (using
    `docker buildx imagetools create` for direct registry-to-registry copy).
  - Switched `containerRepo()` and `harnessHost.c` to point at the mirrored
    namespace so CI no longer depends on the upstream maintainer continuing
    to host these images.
  - Whitelisted the new `scripts/mirror-test-images.sh` (mode 0755) in
    test.pl's executable-file allowlist so `code-format` passes.

  Note: using the maintainer's personal `misterraindrop1` Docker Hub
  namespace because Docker Hub no longer offers free org creation. If we
  later set up a paid `pgbunker` org, this can move there with a
  search/replace.

  ## Test plan

  - [x] CI run on this branch: 14/14 jobs green
    (https://github.com/pgbunker/pgbunker/actions/runs/25056369120)
  - [x] All VM-based tests successfully pulled from `misterraindrop1/test`
  - [x] `code-format` job passes (whitelist fix verified)