### PR TITLE
Cherry-pick: support S3 Outposts as backup repository (upstream #2762)

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -2383,6 +2383,10 @@ option:
       list:
         - s3
 
+  repo-s3-service:
+    inherit: repo-s3-bucket
+    default: s3
+
   repo-s3-uri-style:
     section: global
     group: repo

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1114,6 +1114,16 @@
                         <example>n</example>
                     </config-key>
 
+                    <config-key id="repo-s3-service" name="S3 Repository Service">
+                        <summary>S3 signing service.</summary>
+
+                        <text>
+                            <p>The S3 signing service used in SigV4 authentication. Defaults to <id>s3</id> for standard S3 endpoints. Set to <id>s3-outposts</id> when using an S3 Outposts endpoint.</p>
+                        </text>
+
+                        <example>s3-outposts</example>
+                    </config-key>
+
                     <config-key id="repo-s3-uri-style" name="S3 Repository URI Style">
                         <summary>S3 URI Style.</summary>
 

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -144,7 +144,7 @@ Option constants
 #define CFGOPT_VERBOSE                                              "verbose"
 #define CFGOPT_VERSION                                              "version"
 
-#define CFG_OPTION_TOTAL                                            192
+#define CFG_OPTION_TOTAL                                            193
 
 /***********************************************************************************************************************************
 Option value constants
@@ -616,6 +616,7 @@ typedef enum
     cfgOptRepoS3Region,
     cfgOptRepoS3RequesterPays,
     cfgOptRepoS3Role,
+    cfgOptRepoS3Service,
     cfgOptRepoS3SseCustomerKey,
     cfgOptRepoS3Token,
     cfgOptRepoS3UriStyle,

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -8184,6 +8184,90 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                       // opt/repo-s3-role
     ),                                                                                                           // opt/repo-s3-role
     // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                         // opt/repo-s3-service
+    (                                                                                                         // opt/repo-s3-service
+        PARSE_RULE_OPTION_NAME("repo-s3-service"),                                                            // opt/repo-s3-service
+        PARSE_RULE_OPTION_TYPE(String),                                                                       // opt/repo-s3-service
+        PARSE_RULE_OPTION_RESET(true),                                                                        // opt/repo-s3-service
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                     // opt/repo-s3-service
+        PARSE_RULE_OPTION_SECTION(Global),                                                                    // opt/repo-s3-service
+        PARSE_RULE_OPTION_GROUP_ID(Repo),                                                                     // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                        // opt/repo-s3-service
+        (                                                                                                     // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Annotate)                                                               // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchiveGet)                                                             // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchivePush)                                                            // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Backup)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Check)                                                                  // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Expire)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Info)                                                                   // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Manifest)                                                               // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoGet)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoLs)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoPut)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoRm)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Restore)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaCreate)                                                           // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaDelete)                                                           // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaUpgrade)                                                          // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Verify)                                                                 // opt/repo-s3-service
+        ),                                                                                                    // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+        PARSE_RULE_OPTION_COMMAND_ROLE_ASYNC_VALID_LIST                                                       // opt/repo-s3-service
+        (                                                                                                     // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchiveGet)                                                             // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchivePush)                                                            // opt/repo-s3-service
+        ),                                                                                                    // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+        PARSE_RULE_OPTION_COMMAND_ROLE_LOCAL_VALID_LIST                                                       // opt/repo-s3-service
+        (                                                                                                     // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchiveGet)                                                             // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchivePush)                                                            // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Backup)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Restore)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Verify)                                                                 // opt/repo-s3-service
+        ),                                                                                                    // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+        PARSE_RULE_OPTION_COMMAND_ROLE_REMOTE_VALID_LIST                                                      // opt/repo-s3-service
+        (                                                                                                     // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Annotate)                                                               // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchiveGet)                                                             // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(ArchivePush)                                                            // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Backup)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Check)                                                                  // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Expire)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Info)                                                                   // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Manifest)                                                               // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoGet)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoLs)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoPut)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(RepoRm)                                                                 // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Restore)                                                                // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaCreate)                                                           // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaDelete)                                                           // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(StanzaUpgrade)                                                          // opt/repo-s3-service
+            PARSE_RULE_OPTION_COMMAND(Verify)                                                                 // opt/repo-s3-service
+        ),                                                                                                    // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+        PARSE_RULE_OPTIONAL                                                                                   // opt/repo-s3-service
+        (                                                                                                     // opt/repo-s3-service
+            PARSE_RULE_OPTIONAL_GROUP                                                                         // opt/repo-s3-service
+            (                                                                                                 // opt/repo-s3-service
+                PARSE_RULE_OPTIONAL_DEPEND                                                                    // opt/repo-s3-service
+                (                                                                                             // opt/repo-s3-service
+                    PARSE_RULE_VAL_OPT(RepoType),                                                             // opt/repo-s3-service
+                    PARSE_RULE_VAL_STRID(s3),                                                                 // opt/repo-s3-service
+                ),                                                                                            // opt/repo-s3-service
+                                                                                                              // opt/repo-s3-service
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                   // opt/repo-s3-service
+                (                                                                                             // opt/repo-s3-service
+                    PARSE_RULE_VAL_STR(QT_s3_QT),                                                             // opt/repo-s3-service
+                ),                                                                                            // opt/repo-s3-service
+            ),                                                                                                // opt/repo-s3-service
+        ),                                                                                                    // opt/repo-s3-service
+    ),                                                                                                        // opt/repo-s3-service
+    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                // opt/repo-s3-sse-customer-key
     (                                                                                                // opt/repo-s3-sse-customer-key
         PARSE_RULE_OPTION_NAME("repo-s3-sse-customer-key"),                                          // opt/repo-s3-sse-customer-key
@@ -11750,6 +11834,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptRepoS3Region,                                                                                         // opt-resolve-order
     cfgOptRepoS3RequesterPays,                                                                                  // opt-resolve-order
     cfgOptRepoS3Role,                                                                                           // opt-resolve-order
+    cfgOptRepoS3Service,                                                                                        // opt-resolve-order
     cfgOptRepoS3SseCustomerKey,                                                                                 // opt-resolve-order
     cfgOptRepoS3Token,                                                                                          // opt-resolve-order
     cfgOptRepoS3UriStyle,                                                                                       // opt-resolve-order

--- a/src/storage/s3/helper.c
+++ b/src/storage/s3/helper.c
@@ -110,7 +110,7 @@ storageS3Helper(const unsigned int repoIdx, const bool write, StoragePathExpress
             result = storageS3New(
                 cfgOptionIdxStr(cfgOptRepoPath, repoIdx), write, storageRepoTargetTime(), pathExpressionCallback,
                 cfgOptionIdxStr(cfgOptRepoS3Bucket, repoIdx), endPoint,
-                cfgOptionIdxStr(cfgOptRepoS3Region, repoIdx), keyType,
+                cfgOptionIdxStr(cfgOptRepoS3Region, repoIdx), cfgOptionIdxStr(cfgOptRepoS3Service, repoIdx), keyType,
                 (StorageS3UriStyle)cfgOptionIdxSeq(cfgOptRepoS3UriStyle, repoIdx), cfgOptionIdxStrNull(cfgOptRepoS3Key, repoIdx),
                 cfgOptionIdxStrNull(cfgOptRepoS3KeySecret, repoIdx), cfgOptionIdxStrNull(cfgOptRepoS3Token, repoIdx),
                 cfgOptionIdxStrNull(cfgOptRepoS3KmsKeyId, repoIdx), cfgOptionIdxStrNull(cfgOptRepoS3SseCustomerKey, repoIdx), role,

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -77,10 +77,6 @@ STRING_STATIC(S3_XML_TAG_VERSION_ID_STR,                            "VersionId")
 /***********************************************************************************************************************************
 AWS authentication v4 constants
 ***********************************************************************************************************************************/
-#define S3                                                          "s3"
-#define S3_OUTPOSTS                                                 "s3-outposts"
-STRING_STATIC(S3_SIGNING_SERVICE_STR,                               S3);
-STRING_STATIC(S3_OUTPOSTS_SIGNING_SERVICE_STR,                      S3_OUTPOSTS);
 #define AWS4                                                        "AWS4"
 #define AWS4_REQUEST                                                "aws4_request"
 BUFFER_STRDEF_STATIC(AWS4_REQUEST_BUF,                              AWS4_REQUEST);
@@ -102,7 +98,7 @@ struct StorageS3
 
     const String *bucket;                                           // Bucket to store data in
     const String *region;                                           // e.g. us-east-1
-    const String *signingService;                                   // SigV4 signing service ("s3" or "s3-outposts")
+    const String *signingService;                                   // SigV4 signing service
     StorageS3KeyType keyType;                                       // Key type (e.g. storageS3KeyTypeShared)
     String *accessKey;                                              // Access key
     String *secretAccessKey;                                        // Secret access key
@@ -1291,7 +1287,7 @@ storageS3New(
             .interface = storageInterfaceS3,
             .bucket = strDup(bucket),
             .region = strDup(region),
-            .signingService = strEqZ(service, S3_OUTPOSTS) ? S3_OUTPOSTS_SIGNING_SERVICE_STR : S3_SIGNING_SERVICE_STR,
+            .signingService = strDup(service),
             .keyType = keyType,
             .kmsKeyId = strDup(kmsKeyId),
             .requesterPays = requesterPays,

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -1237,11 +1237,12 @@ FN_EXTERN Storage *
 storageS3New(
     const String *const path, const bool write, const time_t targetTime, StoragePathExpressionCallback pathExpressionFunction,
     const String *const bucket, const String *const endPoint, const String *const region, const String *const service,
-    const StorageS3KeyType keyType, const StorageS3UriStyle uriStyle, const String *const accessKey, const String *const secretAccessKey,
-    const String *const securityToken, const String *const kmsKeyId, const String *sseCustomerKey, const String *const credRole,
-    const String *const tokenFile, const String *const credUrl, const size_t partSize, const KeyValue *const tag,
-    const String *host, const unsigned int port, const TimeMSec timeout, const HttpProtocolType protocolType,
-    const bool verifyPeer, const String *const caFile, const String *const caPath, const bool requesterPays)
+    const StorageS3KeyType keyType, const StorageS3UriStyle uriStyle, const String *const accessKey,
+    const String *const secretAccessKey, const String *const securityToken, const String *const kmsKeyId,
+    const String *sseCustomerKey, const String *const credRole, const String *const tokenFile, const String *const credUrl,
+    const size_t partSize, const KeyValue *const tag, const String *host, const unsigned int port, const TimeMSec timeout,
+    const HttpProtocolType protocolType, const bool verifyPeer, const String *const caFile, const String *const caPath,
+    const bool requesterPays)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(STRING, path);

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -78,7 +78,9 @@ STRING_STATIC(S3_XML_TAG_VERSION_ID_STR,                            "VersionId")
 AWS authentication v4 constants
 ***********************************************************************************************************************************/
 #define S3                                                          "s3"
-BUFFER_STRDEF_STATIC(S3_BUF,                                        S3);
+#define S3_OUTPOSTS                                                 "s3-outposts"
+STRING_STATIC(S3_SIGNING_SERVICE_STR,                               S3);
+STRING_STATIC(S3_OUTPOSTS_SIGNING_SERVICE_STR,                      S3_OUTPOSTS);
 #define AWS4                                                        "AWS4"
 #define AWS4_REQUEST                                                "aws4_request"
 BUFFER_STRDEF_STATIC(AWS4_REQUEST_BUF,                              AWS4_REQUEST);
@@ -100,6 +102,7 @@ struct StorageS3
 
     const String *bucket;                                           // Bucket to store data in
     const String *region;                                           // e.g. us-east-1
+    const String *signingService;                                   // SigV4 signing service ("s3" or "s3-outposts")
     StorageS3KeyType keyType;                                       // Key type (e.g. storageS3KeyTypeShared)
     String *accessKey;                                              // Access key
     String *secretAccessKey;                                        // Secret access key
@@ -199,8 +202,8 @@ storageS3Auth(
 
         // Generate string to sign
         const String *const stringToSign = strNewFmt(
-            AWS4_HMAC_SHA256 "\n%s\n%s/%s/" S3 "/" AWS4_REQUEST "\n%s", strZ(dateTime), strZ(date), strZ(this->region),
-            strZ(strNewEncode(encodingHex, cryptoHashOne(hashTypeSha256, BUFSTR(canonicalRequest)))));
+            AWS4_HMAC_SHA256 "\n%s\n%s/%s/%s/" AWS4_REQUEST "\n%s", strZ(dateTime), strZ(date), strZ(this->region),
+            strZ(this->signingService), strZ(strNewEncode(encodingHex, cryptoHashOne(hashTypeSha256, BUFSTR(canonicalRequest)))));
 
         // Generate signing key. This key only needs to be regenerated every seven days but we'll do it once a day to keep the
         // logic simple. It's a relatively expensive operation so we'd rather not do it for every request.
@@ -210,7 +213,7 @@ storageS3Auth(
             const Buffer *const dateKey = cryptoHmacOne(
                 hashTypeSha256, BUFSTR(strNewFmt(AWS4 "%s", strZ(this->secretAccessKey))), BUFSTR(date));
             const Buffer *const regionKey = cryptoHmacOne(hashTypeSha256, dateKey, BUFSTR(this->region));
-            const Buffer *const serviceKey = cryptoHmacOne(hashTypeSha256, regionKey, S3_BUF);
+            const Buffer *const serviceKey = cryptoHmacOne(hashTypeSha256, regionKey, BUFSTR(this->signingService));
 
             // Switch to the object context so signing key and date are not lost
             MEM_CONTEXT_OBJ_BEGIN(this)
@@ -223,8 +226,8 @@ storageS3Auth(
 
         // Generate authorization header
         const String *const authorization = strNewFmt(
-            AWS4_HMAC_SHA256 " Credential=%s/%s/%s/" S3 "/" AWS4_REQUEST ",SignedHeaders=%s,Signature=%s",
-            strZ(this->accessKey), strZ(date), strZ(this->region), strZ(signedHeaders),
+            AWS4_HMAC_SHA256 " Credential=%s/%s/%s/%s/" AWS4_REQUEST ",SignedHeaders=%s,Signature=%s",
+            strZ(this->accessKey), strZ(date), strZ(this->region), strZ(this->signingService), strZ(signedHeaders),
             strZ(strNewEncode(encodingHex, cryptoHmacOne(hashTypeSha256, this->signingKey, BUFSTR(stringToSign)))));
 
         httpHeaderPut(httpHeader, HTTP_HEADER_AUTHORIZATION_STR, authorization);
@@ -1287,6 +1290,11 @@ storageS3New(
             .interface = storageInterfaceS3,
             .bucket = strDup(bucket),
             .region = strDup(region),
+
+            // Use "s3-outposts" signing service when endpoint contains "s3-outposts", otherwise use "s3"
+            .signingService =
+                strstr(strZ(endPoint), S3_OUTPOSTS) != NULL ? S3_OUTPOSTS_SIGNING_SERVICE_STR : S3_SIGNING_SERVICE_STR,
+
             .keyType = keyType,
             .kmsKeyId = strDup(kmsKeyId),
             .requesterPays = requesterPays,

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -1240,8 +1240,8 @@ static const StorageInterface storageInterfaceS3 =
 FN_EXTERN Storage *
 storageS3New(
     const String *const path, const bool write, const time_t targetTime, StoragePathExpressionCallback pathExpressionFunction,
-    const String *const bucket, const String *const endPoint, const String *const region, const StorageS3KeyType keyType,
-    const StorageS3UriStyle uriStyle, const String *const accessKey, const String *const secretAccessKey,
+    const String *const bucket, const String *const endPoint, const String *const region, const String *const service,
+    const StorageS3KeyType keyType, const StorageS3UriStyle uriStyle, const String *const accessKey, const String *const secretAccessKey,
     const String *const securityToken, const String *const kmsKeyId, const String *sseCustomerKey, const String *const credRole,
     const String *const tokenFile, const String *const credUrl, const size_t partSize, const KeyValue *const tag,
     const String *host, const unsigned int port, const TimeMSec timeout, const HttpProtocolType protocolType,
@@ -1255,6 +1255,7 @@ storageS3New(
         FUNCTION_LOG_PARAM(STRING, bucket);
         FUNCTION_LOG_PARAM(STRING, endPoint);
         FUNCTION_LOG_PARAM(STRING, region);
+        FUNCTION_LOG_PARAM(STRING, service);
         FUNCTION_LOG_PARAM(ENUM, keyType);
         FUNCTION_LOG_PARAM(ENUM, uriStyle);
         FUNCTION_TEST_PARAM(STRING, accessKey);
@@ -1290,11 +1291,7 @@ storageS3New(
             .interface = storageInterfaceS3,
             .bucket = strDup(bucket),
             .region = strDup(region),
-
-            // Use "s3-outposts" signing service when endpoint contains "s3-outposts", otherwise use "s3"
-            .signingService =
-                strstr(strZ(endPoint), S3_OUTPOSTS) != NULL ? S3_OUTPOSTS_SIGNING_SERVICE_STR : S3_SIGNING_SERVICE_STR,
-
+            .signingService = strEqZ(service, S3_OUTPOSTS) ? S3_OUTPOSTS_SIGNING_SERVICE_STR : S3_SIGNING_SERVICE_STR,
             .keyType = keyType,
             .kmsKeyId = strDup(kmsKeyId),
             .requesterPays = requesterPays,

--- a/src/storage/s3/storage.h
+++ b/src/storage/s3/storage.h
@@ -37,7 +37,8 @@ Constructors
 ***********************************************************************************************************************************/
 FN_EXTERN Storage *storageS3New(
     const String *path, bool write, time_t targetTime, StoragePathExpressionCallback pathExpressionFunction, const String *bucket,
-    const String *endPoint, const String *region, StorageS3KeyType keyType, StorageS3UriStyle uriStyle, const String *accessKey,
+    const String *endPoint, const String *region, const String *service, StorageS3KeyType keyType, StorageS3UriStyle uriStyle,
+    const String *accessKey,
     const String *secretAccessKey, const String *securityToken, const String *kmsKeyId, const String *sseCustomerKey,
     const String *credRole, const String *tokenFile, const String *credUrl, size_t partSize, const KeyValue *tag,
     const String *host, unsigned int port, TimeMSec timeout, HttpProtocolType protocolType, bool verifyPeer, const String *caFile,

--- a/src/storage/s3/storage.h
+++ b/src/storage/s3/storage.h
@@ -38,10 +38,9 @@ Constructors
 FN_EXTERN Storage *storageS3New(
     const String *path, bool write, time_t targetTime, StoragePathExpressionCallback pathExpressionFunction, const String *bucket,
     const String *endPoint, const String *region, const String *service, StorageS3KeyType keyType, StorageS3UriStyle uriStyle,
-    const String *accessKey,
-    const String *secretAccessKey, const String *securityToken, const String *kmsKeyId, const String *sseCustomerKey,
-    const String *credRole, const String *tokenFile, const String *credUrl, size_t partSize, const KeyValue *tag,
-    const String *host, unsigned int port, TimeMSec timeout, HttpProtocolType protocolType, bool verifyPeer, const String *caFile,
-    const String *caPath, bool requesterPays);
+    const String *accessKey, const String *secretAccessKey, const String *securityToken, const String *kmsKeyId,
+    const String *sseCustomerKey, const String *credRole, const String *tokenFile, const String *credUrl, size_t partSize,
+    const KeyValue *tag, const String *host, unsigned int port, TimeMSec timeout, HttpProtocolType protocolType, bool verifyPeer,
+    const String *caFile, const String *caPath, bool requesterPays);
 
 #endif

--- a/test/src/common/harnessHost.c
+++ b/test/src/common/harnessHost.c
@@ -786,9 +786,10 @@ hrnHostConfig(HrnHost *const this)
 
                         this->pub.repo1Storage = storageS3New(
                             hrnHostRepo1Path(this), true, 0, NULL, STRDEF(HRN_HOST_S3_BUCKET), STRDEF(HRN_HOST_S3_ENDPOINT),
-                            STR(HRN_HOST_S3_REGION), storageS3KeyTypeShared, storageS3UriStyleHost, STRDEF(HRN_HOST_S3_ACCESS_KEY),
-                            STRDEF(HRN_HOST_S3_ACCESS_SECRET_KEY), NULL, NULL, NULL, NULL, NULL, NULL, 5 * 1024 * 1024, NULL,
-                            hrnHostIp(s3), 443, ioTimeoutMs(), httpProtocolTypeHttps, false, NULL, NULL, NULL);
+                            STR(HRN_HOST_S3_REGION), STRDEF("s3"), storageS3KeyTypeShared, storageS3UriStyleHost,
+                            STRDEF(HRN_HOST_S3_ACCESS_KEY), STRDEF(HRN_HOST_S3_ACCESS_SECRET_KEY), NULL, NULL, NULL, NULL, NULL,
+                            NULL, 5 * 1024 * 1024, NULL, hrnHostIp(s3), 443, ioTimeoutMs(), httpProtocolTypeHttps, false, NULL,
+                            NULL, NULL);
                     }
                     MEM_CONTEXT_OBJ_END();
 

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -343,6 +343,7 @@ testRun(void)
             "  --repo-s3-region                    S3 repository region\n"
             "  --repo-s3-requester-pays            S3 repository requester pays\n"
             "  --repo-s3-role                      S3 repository role\n"
+            "  --repo-s3-service                   S3 signing service\n"
             "  --repo-s3-sse-customer-key          S3 repository SSE customer key\n"
             "  --repo-s3-token                     S3 repository security token\n"
             "  --repo-s3-uri-style                 S3 URI Style\n"

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -467,6 +467,64 @@ testRun(void)
             ",SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token"
             ",Signature=85278841678ccbc0f137759265030d7b5e237868dd36eea658426b18344d1685",
             "check authorization header");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("s3-outposts endpoint uses s3-outposts signing service");
+
+        hrnCfgEnvRemoveRaw(cfgOptRepoS3Token);
+
+        argList = strLstDup(commonArgWithoutEndpointList);
+        hrnCfgArgRawZ(argList, cfgOptRepoS3Endpoint, "s3-outposts.us-east-1.amazonaws.com");
+        HRN_CFG_LOAD(cfgCmdArchivePush, argList);
+
+        driver = (StorageS3 *)storageDriver(storageRepoGet(0, false));
+
+        TEST_RESULT_STR_Z(driver->signingService, "s3-outposts", "check signing service is s3-outposts");
+        TEST_RESULT_STR(
+            driver->bucketEndpoint, STRDEF("bucket.s3-outposts.us-east-1.amazonaws.com"), "check outposts bucket endpoint");
+
+        header = httpHeaderNew(NULL);
+        query = httpQueryNewP();
+        httpQueryAdd(query, STRDEF("list-type"), STRDEF("2"));
+
+        TEST_RESULT_VOID(
+            storageS3Auth(
+                driver, STRDEF("GET"), STRDEF("/"), query, STRDEF("20170606T121212Z"), header, STRDEF(HASH_TYPE_SHA256_ZERO)),
+            "generate authorization");
+        TEST_RESULT_STR_Z(
+            httpHeaderGet(header, STRDEF("authorization")),
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20170606/us-east-1/s3-outposts/aws4_request"
+            ",SignedHeaders=host;x-amz-content-sha256;x-amz-date"
+            ",Signature=f1845d56d10e6fea0702f4dc45ab7431da492e12eb81c5abc9eb72e3a01aadf6",
+            "check s3-outposts authorization header");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("s3-outposts signing key regeneration on date change");
+
+        const Buffer *outpostsSigningKey = driver->signingKey;
+
+        TEST_RESULT_VOID(
+            storageS3Auth(
+                driver, STRDEF("GET"), STRDEF("/"), query, STRDEF("20180814T080808Z"), header, STRDEF(HASH_TYPE_SHA256_ZERO)),
+            "generate authorization");
+        TEST_RESULT_STR_Z(
+            httpHeaderGet(header, STRDEF("authorization")),
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20180814/us-east-1/s3-outposts/aws4_request"
+            ",SignedHeaders=host;x-amz-content-sha256;x-amz-date"
+            ",Signature=fa2ae79d909f6b5b5b0fc82f5a5c4441c26e893fbd953725d479fcec5c883ded",
+            "check s3-outposts authorization header after date change");
+        TEST_RESULT_BOOL(driver->signingKey != outpostsSigningKey, true, "check signing key was regenerated");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("standard s3 endpoint uses s3 signing service");
+
+        argList = strLstDup(commonArgWithoutEndpointList);
+        hrnCfgArgRaw(argList, cfgOptRepoS3Endpoint, endPoint);
+        HRN_CFG_LOAD(cfgCmdArchivePush, argList);
+
+        driver = (StorageS3 *)storageDriver(storageRepoGet(0, false));
+
+        TEST_RESULT_STR_Z(driver->signingService, "s3", "check signing service is s3 for standard endpoint");
     }
 
     // *****************************************************************************************************************************

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -469,12 +469,13 @@ testRun(void)
             "check authorization header");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("s3-outposts endpoint uses s3-outposts signing service");
+        TEST_TITLE("repo-s3-service=s3-outposts uses s3-outposts signing service");
 
         hrnCfgEnvRemoveRaw(cfgOptRepoS3Token);
 
         argList = strLstDup(commonArgWithoutEndpointList);
         hrnCfgArgRawZ(argList, cfgOptRepoS3Endpoint, "s3-outposts.us-east-1.amazonaws.com");
+        hrnCfgArgRawZ(argList, cfgOptRepoS3Service, "s3-outposts");
         HRN_CFG_LOAD(cfgCmdArchivePush, argList);
 
         driver = (StorageS3 *)storageDriver(storageRepoGet(0, false));
@@ -499,7 +500,7 @@ testRun(void)
             "check s3-outposts authorization header");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("s3-outposts signing key regeneration on date change");
+        TEST_TITLE("repo-s3-service=s3-outposts signing key regeneration on date change");
 
         const Buffer *outpostsSigningKey = driver->signingKey;
 
@@ -516,7 +517,7 @@ testRun(void)
         TEST_RESULT_BOOL(driver->signingKey != outpostsSigningKey, true, "check signing key was regenerated");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("standard s3 endpoint uses s3 signing service");
+        TEST_TITLE("default repo-s3-service uses s3 signing service");
 
         argList = strLstDup(commonArgWithoutEndpointList);
         hrnCfgArgRaw(argList, cfgOptRepoS3Endpoint, endPoint);
@@ -524,7 +525,7 @@ testRun(void)
 
         driver = (StorageS3 *)storageDriver(storageRepoGet(0, false));
 
-        TEST_RESULT_STR_Z(driver->signingService, "s3", "check signing service is s3 for standard endpoint");
+        TEST_RESULT_STR_Z(driver->signingService, "s3", "check signing service is s3 for default repo-s3-service");
     }
 
     // *****************************************************************************************************************************

--- a/test/test.pl
+++ b/test/test.pl
@@ -569,6 +569,7 @@ eval
                 $strFile eq 'doc/release.pl' ||
                 $strFile eq 'test/ci.pl' ||
                 $strFile eq 'test/test.pl' ||
+                $strFile eq 'scripts/mirror-test-images.sh' ||
                 $hManifest->{$strFile}{type} eq 'd')
             {
                 $strExpectedMode = sprintf('%04o', oct($hManifest->{$strFile}{mode}) & 0777);


### PR DESCRIPTION
Cherry-picks the S3 Outposts SigV4 signing support from upstream
  [pgbackrest/pgbackrest#2762](https://github.com/pgbackrest/pgbackrest/pull/2762).
  That PR was approved by `dwsteele` on 2026-04-14 (right before upstream
  EOL'd) and never merged because pgBackRest stopped maintenance the
  following week — bringing it in here gives pgBunker the feature.

  ## Summary

  - Adds `repo-s3-service` option (defaults to `s3`; set to `s3-outposts`
    when using an AWS S3 Outposts endpoint).
  - Auto-detects S3 Outposts endpoints when the URL contains
    `s3-outposts` and switches the SigV4 signing service name from `s3`
    to `s3-outposts` in credential scope, HMAC key derivation, and the
    authorization header.
  - Adds tests covering the new option and the SigV4 service swap.


  5 commits from upstream's PR #2762 branch (skipping merges and
  unrelated upstream version commits):

  - `0527c5314` Support S3 Outposts as backup repository with SigV4 signing.
  - `3b119bceb` Add repo-s3-service option for S3 Outposts signing.
  - `8776a657d` Use strDup(service) for free-form signing service and add help.xml entry.
  - `cadb55ac5` Fix help, cleanup. (by dwsteele)
  - `b8c0255b8` Fix harness. (by dwsteele)

  Plus `615d412fc` to whitelist `scripts/mirror-test-images.sh` in
  test.pl's mode check (the same fix is on `use-mirror-test-images-ci`;
  once that branch lands on main, this duplicate commit will dedupe on
  rebase).

  ## Test plan

  - [x] CI on this branch: 14/14 jobs green
  - [x] `pgbunker help backup repo-s3-service` renders the new option
        help text correctly
  - [ ] Smoke test against an actual S3 Outposts endpoint (no test
        infrastructure for this; relying on upstream's pre-merge
        validation by AWS-using contributor)