### PR TITLE
Cherry-pick: fadvise(DONTNEED) for posix repo writes (upstream #2758)

### DIFF
--- a/src/storage/posix/read.c
+++ b/src/storage/posix/read.c
@@ -94,7 +94,6 @@ storageReadPosixOpen(THIS_VOID)
         posix_fadvise(this->fd, 0, 0, POSIX_FADV_DONTNEED);
 #endif
 
-
         // Seek to offset
         if (this->interface.offset != 0)
         {

--- a/src/storage/posix/read.c
+++ b/src/storage/posix/read.c
@@ -89,6 +89,12 @@ storageReadPosixOpen(THIS_VOID)
         // Set free callback to ensure the file descriptor is freed
         memContextCallbackSet(objMemContext(this), storageReadPosixFreeResource, this);
 
+        // Hint to the kernel that we won't reuse these blocks. Linux/FreeBSD only - posix_fadvise is not in macOS libc.
+#if defined(__linux__) || defined(__FreeBSD__)
+        posix_fadvise(this->fd, 0, 0, POSIX_FADV_DONTNEED);
+#endif
+
+
         // Seek to offset
         if (this->interface.offset != 0)
         {

--- a/src/storage/posix/write.c
+++ b/src/storage/posix/write.c
@@ -117,6 +117,11 @@ storageWritePosixOpen(THIS_VOID)
     // Set free callback to ensure the file descriptor is freed
     memContextCallbackSet(objMemContext(this), storageWritePosixFreeResource, this);
 
+    // Hint to the kernel that we won't reuse these blocks. Linux/FreeBSD only - posix_fadvise is not in macOS libc.
+#if defined(__linux__) || defined(__FreeBSD__)
+    posix_fadvise(this->fd, 0, 0, POSIX_FADV_DONTNEED);
+#endif
+
     // Update user/group owner
     if (this->interface.user != NULL || this->interface.group != NULL)
     {

--- a/test/test.pl
+++ b/test/test.pl
@@ -569,6 +569,7 @@ eval
                 $strFile eq 'doc/release.pl' ||
                 $strFile eq 'test/ci.pl' ||
                 $strFile eq 'test/test.pl' ||
+                $strFile eq 'scripts/mirror-test-images.sh' ||
                 $hManifest->{$strFile}{type} eq 'd')
             {
                 $strExpectedMode = sprintf('%04o', oct($hManifest->{$strFile}{mode}) & 0777);


### PR DESCRIPTION
Cherry-picks the `posix_fadvise()` cache hint from upstream
  [pgbackrest/pgbackrest#2758](https://github.com/pgbackrest/pgbackrest/pull/2758),
  authored by [@fmbiete](https://github.com/fmbiete) 2026-03-30.

  ## Summary

  `posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED)` on every read/write
  into a posix-type repo tells the kernel not to keep these blocks
  in the page cache. On hosts with large repositories this avoids
  backup operations evicting the database's hot pages from cache.

  The added cost on read/write is one syscall per fd open — negligible
  compared to the actual I/O the call is hinting about.

  ## Diff from upstream

  Upstream's PR called `posix_fadvise()` unconditionally, which fails
  to compile on macOS (the function and `POSIX_FADV_DONTNEED` constant
  are Linux/FreeBSD-only). Upstream's macos_ventura CI was failing for
  this reason and the PR author hadn't addressed it before EOL.

  This branch wraps both call sites in:

  ```c
  #if defined(__linux__) || defined(__FreeBSD__)
  #endif
  ```

  so macOS / other non-Linux/FreeBSD builds compile clean — they just
  skip the hint.

  ## Cherry-picked commits

  - `237b5d793` Set fadvise for repo type posix (upstream)
  - platform guard added on amend (Linux/FreeBSD only)
  - `8e63ee483` Remove stray blank line for uncrustify
  - `615d412fc` Whitelist `scripts/mirror-test-images.sh` (same as
    other cherry-pick PRs)

  ## Test plan

  - [x] CI on this branch: 14/14 jobs green (Linux unit / freebsd /
        arch / aarch64 / macos all clean)
  - [ ] Quantitative perf measurement on a representative workload —
        not done; relying on the upstream PR's reasoning that the
        cache pollution is well-known and the fix is the standard one
        ([pgbackrest issue #1038](https://github.com/pgbackrest/pgbackrest/issues/1038)
        for context)