### PR TITLE
Clean up stale pgBackRest references in user-facing docs.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,17 @@
 Please provide the following information when submitting an issue (feature requests or general comments can skip this):
 
-1. pgBackRest version:
+1. pgBunker version:
 
 2. PostgreSQL version:
 
 3. Operating system/version - if you have more than one server (for example, a database server, a repository host server, one or more standbys), please specify each:
 
-4. Did you install pgBackRest from source or from a package?
+4. Did you install pgBunker from source or from a package?
 
 5. Please attach the following as applicable:
-    - `pgbackrest.conf` file(s)
-    - `postgresql.conf` settings applicable to pgBackRest (`archive_command`, `archive_mode`, `listen_addresses`, `max_wal_senders`, `wal_level`, `port`)
+    - `pgbunker.conf` file(s) (or `pgbackrest.conf` if migrated from upstream)
+    - `postgresql.conf` settings applicable to pgBunker (`archive_command`, `archive_mode`, `listen_addresses`, `max_wal_senders`, `wal_level`, `port`)
     - errors in the postgresql log file before or during the time you experienced the issue
-    - log file in `/var/log/pgbackrest` for the commands run (e.g. `/var/log/pgbackrest/mystanza_backup.log`)
+    - log file in `/var/log/pgbunker` for the commands run (e.g. `/var/log/pgbunker/mystanza_backup.log`)
 
 7. Describe the issue:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# pgBackRest <br/> Contributing to pgBackRest
+# pgBunker <br/> Contributing to pgBunker
 
 ## Table of Contents
 
@@ -14,21 +14,21 @@
 
 ## Introduction
 
-This documentation is intended to assist contributors to pgBackRest by outlining some basic steps and guidelines for contributing to the project.
+This documentation is intended to assist contributors to pgBunker by outlining some basic steps and guidelines for contributing to the project.
 
-Code fixes or new features can be submitted via pull requests. Ideas for new features and improvements to existing functionality or documentation can be [submitted as issues](https://github.com/pgbackrest/pgbackrest/issues). You may want to check the [Project Boards](https://github.com/pgbackrest/pgbackrest/projects) to see if your suggestion has already been submitted.
+Code fixes or new features can be submitted via pull requests. Ideas for new features and improvements to existing functionality or documentation can be [submitted as issues](https://github.com/pgbunker/pgbunker/issues). You may want to check the [Project Boards](https://github.com/pgbunker/pgbunker/projects) to see if your suggestion has already been submitted.
 
-Bug reports should be [submitted as issues](https://github.com/pgbackrest/pgbackrest/issues). Please provide as much information as possible to aid in determining the cause of the problem.
+Bug reports should be [submitted as issues](https://github.com/pgbunker/pgbunker/issues). Please provide as much information as possible to aid in determining the cause of the problem.
 
-You will always receive credit in the [release notes](http://www.pgbackrest.org/release.html) for your contributions.
+You will always receive credit in the [release notes](https://github.com/pgbunker/pgbunker/blob/main/doc/NEWS.md) for your contributions.
 
-Coding standards are defined in [CODING.md](https://github.com/pgbackrest/pgbackrest/blob/main/CODING.md) and some important coding details and an example are provided in the [Coding](#coding) section below. At a minimum, unit tests must be written and run and the documentation generated before [submitting a Pull Request](#submitting-a-pull-request); see the [Testing](#testing) section below for details.
+Coding standards are defined in [CODING.md](https://github.com/pgbunker/pgbunker/blob/main/CODING.md) and some important coding details and an example are provided in the [Coding](#coding) section below. At a minimum, unit tests must be written and run and the documentation generated before [submitting a Pull Request](#submitting-a-pull-request); see the [Testing](#testing) section below for details.
 
 ## Building a Development Environment
 
 This example is based on Ubuntu 22.04, but it should work on many versions of Debian and Ubuntu.
 
-pgbackrest-dev => Install development tools
+pgbunker-dev => Install development tools
 ```
 sudo apt-get install rsync git devscripts build-essential valgrind autoconf \
        autoconf-archive libssl-dev zlib1g-dev libxml2-dev libpq-dev pkg-config \
@@ -38,38 +38,38 @@ sudo apt-get install rsync git devscripts build-essential valgrind autoconf \
 
 Some unit tests and all the integration tests require Docker. Running in containers allows us to simulate multiple hosts, test on different distributions and versions of PostgreSQL, and use sudo without affecting the host system.
 
-pgbackrest-dev => Install Docker
+pgbunker-dev => Install Docker
 ```
 curl -fsSL https://get.docker.com | sudo sh
 sudo usermod -aG docker `whoami`
 ```
 
-This clone of the pgBackRest repository is sufficient for experimentation. For development, create a fork and clone that instead.
+This clone of the pgBunker repository is sufficient for experimentation. For development, create a fork and clone that instead.
 
-pgbackrest-dev => Clone pgBackRest repository
+pgbunker-dev => Clone pgBunker repository
 ```
-git clone https://github.com/pgbackrest/pgbackrest.git
+git clone https://github.com/pgbunker/pgbunker.git
 ```
 
-If using a RHEL-based system, the CPAN XML parser is required to run `test.pl` and `doc.pl`. Instructions for installing Docker and the XML parser can be found in the `README.md` file of the pgBackRest [doc](https://github.com/pgbackrest/pgbackrest/blob/main/doc) directory in the section "The following is a sample RHEL 7 configuration that can be used for building the documentation".
+If using a RHEL-based system, the CPAN XML parser is required to run `test.pl` and `doc.pl`. Instructions for installing Docker and the XML parser can be found in the `README.md` file of the pgBunker [doc](https://github.com/pgbunker/pgbunker/blob/main/doc) directory in the section "The following is a sample RHEL 7 configuration that can be used for building the documentation".
 
 ## Coding
 
-The following sections provide information on some important concepts needed for coding within pgBackRest.
+The following sections provide information on some important concepts needed for coding within pgBunker.
 
 ### Memory Contexts
 
-Memory is allocated inside contexts and can be long lasting (for objects) or temporary (for functions). In general, use `OBJ_NEW_BEGIN(MyObj)` for objects and `MEM_CONTEXT_TEMP_BEGIN()` for functions. See [memContext.h](https://github.com/pgbackrest/pgbackrest/blob/main/src/common/memContext.h) for more details and the [Coding Example](#coding-example) below.
+Memory is allocated inside contexts and can be long lasting (for objects) or temporary (for functions). In general, use `OBJ_NEW_BEGIN(MyObj)` for objects and `MEM_CONTEXT_TEMP_BEGIN()` for functions. See [memContext.h](https://github.com/pgbunker/pgbunker/blob/main/src/common/memContext.h) for more details and the [Coding Example](#coding-example) below.
 
 ### Logging
 
-Logging is used for debugging with the built-in macros `FUNCTION_LOG_*()` and `FUNCTION_TEST_*()` which are used to trace parameters passed to/returned from functions. `FUNCTION_LOG_*()` macros are used for production logging whereas `FUNCTION_TEST_*()` macros will be compiled out of production code. For functions where no parameter is valuable enough to justify the cost of debugging in production, use `FUNCTION_TEST_BEGIN()/FUNCTION_TEST_END()`, else use `FUNCTION_LOG_BEGIN(someLogLevel)/FUNCTION_LOG_END()`. See [debug.h](https://github.com/pgbackrest/pgbackrest/blob/main/src/common/debug.h) for more details and the [Coding Example](#coding-example) below.
+Logging is used for debugging with the built-in macros `FUNCTION_LOG_*()` and `FUNCTION_TEST_*()` which are used to trace parameters passed to/returned from functions. `FUNCTION_LOG_*()` macros are used for production logging whereas `FUNCTION_TEST_*()` macros will be compiled out of production code. For functions where no parameter is valuable enough to justify the cost of debugging in production, use `FUNCTION_TEST_BEGIN()/FUNCTION_TEST_END()`, else use `FUNCTION_LOG_BEGIN(someLogLevel)/FUNCTION_LOG_END()`. See [debug.h](https://github.com/pgbunker/pgbunker/blob/main/src/common/debug.h) for more details and the [Coding Example](#coding-example) below.
 
-Logging is also used for providing information to the user via the `LOG_*()` macros, such as `LOG_INFO("some informational message")` and `LOG_WARN_FMT("no prior backup exists, %s backup has been changed to full", strZ(cfgOptionDisplay(cfgOptType)))` and also via `THROW_*()` macros for throwing an error. See [log.h](https://github.com/pgbackrest/pgbackrest/blob/main/src/common/log.h) and [error.h](https://github.com/pgbackrest/pgbackrest/blob/main/src/common/error/error.h) for more details and the [Coding Example](#coding-example) below.
+Logging is also used for providing information to the user via the `LOG_*()` macros, such as `LOG_INFO("some informational message")` and `LOG_WARN_FMT("no prior backup exists, %s backup has been changed to full", strZ(cfgOptionDisplay(cfgOptType)))` and also via `THROW_*()` macros for throwing an error. See [log.h](https://github.com/pgbunker/pgbunker/blob/main/src/common/log.h) and [error.h](https://github.com/pgbunker/pgbunker/blob/main/src/common/error/error.h) for more details and the [Coding Example](#coding-example) below.
 
 ### Coding Example
 
-The example below is not structured like an actual implementation and is intended only to provide an understanding of some of the more common coding practices. The comments in the example are only here to explain the example and are not representative of the coding standards. Refer to the Coding Standards document ([CODING.md](https://github.com/pgbackrest/pgbackrest/blob/main/CODING.md)) and sections above for an introduction to the concepts provided here. For an actual implementation, see [db.h](https://github.com/pgbackrest/pgbackrest/blob/main/src/db/db.h) and [db.c](https://github.com/pgbackrest/pgbackrest/blob/main/src/db/db.c).
+The example below is not structured like an actual implementation and is intended only to provide an understanding of some of the more common coding practices. The comments in the example are only here to explain the example and are not representative of the coding standards. Refer to the Coding Standards document ([CODING.md](https://github.com/pgbunker/pgbunker/blob/main/CODING.md)) and sections above for an introduction to the concepts provided here. For an actual implementation, see [db.h](https://github.com/pgbunker/pgbunker/blob/main/src/db/db.h) and [db.c](https://github.com/pgbunker/pgbunker/blob/main/src/db/db.c).
 
 #### Example: hypothetical basic object construction
 ```c
@@ -191,15 +191,15 @@ myObjToLog(const MyObj *this)
 
 A list of all possible test combinations can be viewed by running:
 ```
-pgbackrest/test/test.pl --dry-run
+pgbunker/test/test.pl --dry-run
 ```
 While some files are automatically generated during `make`, others are generated by running the test harness as follows:
 ```
-pgbackrest/test/test.pl --gen-only
+pgbunker/test/test.pl --gen-only
 ```
-Prior to any submission, the html version of the documentation should also be run and the output checked by viewing the generated html on the local file system under `pgbackrest/doc/output/html`. More details can be found in the pgBackRest [doc/README.md](https://github.com/pgbackrest/pgbackrest/blob/main/doc/README.md) file.
+Prior to any submission, the html version of the documentation should also be run and the output checked by viewing the generated html on the local file system under `pgbunker/doc/output/html`. More details can be found in the pgBunker [doc/README.md](https://github.com/pgbunker/pgbunker/blob/main/doc/README.md) file.
 ```
-pgbackrest/doc/doc.pl --out=html
+pgbunker/doc/doc.pl --out=html
 ```
 > **NOTE:** `ERROR: [028]` regarding cache is invalid is OK; it just means there have been changes and the documentation will be built from scratch. In this case, be patient as the build could take 20 minutes or more depending on your system.
 
@@ -217,21 +217,21 @@ Examples of test runs are provided in the following sections. There are several 
 
 - `--vm-out` - displays the test output (helpful for monitoring the progress)
 
-- `--vm` - identifies the pre-built container when using Docker, otherwise the setting should be `none`. See [test.yml](https://github.com/pgbackrest/pgbackrest/blob/main/.github/workflows/test.yml) for a list of valid vm codes noted by `param: test`.
+- `--vm` - identifies the pre-built container when using Docker, otherwise the setting should be `none`. See [test.yml](https://github.com/pgbunker/pgbunker/blob/main/.github/workflows/test.yml) for a list of valid vm codes noted by `param: test`.
 
 For more options, run the test or documentation engine with the `--help` option:
 ```
-pgbackrest/test/test.pl --help
-pgbackrest/doc/doc.pl --help
+pgbunker/test/test.pl --help
+pgbunker/doc/doc.pl --help
 ```
 
 #### Without Docker
 
 If Docker is not installed, then the available tests can be listed using `--dry-run`. Some tests require containers and will only be available when Docker is installed.
 
-pgbackrest-dev => List tests that don't require a container
+pgbunker-dev => List tests that don't require a container
 ```
-pgbackrest/test/test.pl --dry-run
+pgbunker/test/test.pl --dry-run
 
 --- output ---
 
@@ -246,9 +246,9 @@ pgbackrest/test/test.pl --dry-run
 --> P00   INFO: DRY RUN COMPLETED SUCCESSFULLY
 ```
 
-pgbackrest-dev => Run a test
+pgbunker-dev => Run a test
 ```
-pgbackrest/test/test.pl --vm-out --module=common --test=wait
+pgbunker/test/test.pl --vm-out --module=common --test=wait
 
 --- output ---
 
@@ -319,9 +319,9 @@ pgbackrest/test/test.pl --vm-out --module=common --test=wait
 
 An entire module can be run by using only the `--module` option.
 
-pgbackrest-dev => Run a module
+pgbunker-dev => Run a module
 ```
-pgbackrest/test/test.pl --module=postgres
+pgbunker/test/test.pl --module=postgres
 
 --- output ---
 
@@ -341,22 +341,22 @@ pgbackrest/test/test.pl --module=postgres
 
 Build a container to run tests. The vm must be pre-configured but a variety are available. A vagrant file is provided in the test directory as an example of running in a virtual environment. The vm names are all three character abbreviations, e.g. `u22` for Ubuntu 22.04.
 
-pgbackrest-dev => Build a VM
+pgbunker-dev => Build a VM
 ```
-pgbackrest/test/test.pl --vm-build --vm=u22
+pgbunker/test/test.pl --vm-build --vm=u22
 
 --- output ---
 
     P00   INFO: test begin on x86_64 - log level info
-    P00   INFO: Using cached pgbackrest/test:u22-base-x86_64-20260119A image (8ee008aecbcf21b205116969db4000838c989a4a) ...
-    P00   INFO: Building pgbackrest/test:u22-test-x86_64 image ...
+    P00   INFO: Using cached pgbunker/test:u22-base-x86_64-20260119A image (8ee008aecbcf21b205116969db4000838c989a4a) ...
+    P00   INFO: Building pgbunker/test:u22-test-x86_64 image ...
     P00   INFO: Build Complete
 ```
 > **NOTE:** to build all the vms, just omit the `--vm` option above.
 
-pgbackrest-dev => Run a Specific Test Run
+pgbunker-dev => Run a Specific Test Run
 ```
-pgbackrest/test/test.pl --vm=u22 --module=postgres --test=interface --run=2
+pgbunker/test/test.pl --vm=u22 --module=postgres --test=interface --run=2
 
 --- output ---
 
@@ -411,7 +411,7 @@ if (testBegin("expireBackup()"))
 
 #### Setting up the command to be run
 
-The [harnessConfig.h](https://github.com/pgbackrest/pgbackrest/blob/main/test/src/common/harnessConfig.h) describes a list of functions that should be used when configuration options are required for a command being tested. Options are set in a `StringList` which must be defined and passed to the `HRN_CFG_LOAD()` macro with the command. For example, the following will set up a test to run `pgbackrest --repo-path=test/test-0/repo info` command on multiple repositories, one of which is encrypted:
+The [harnessConfig.h](https://github.com/pgbunker/pgbunker/blob/main/test/src/common/harnessConfig.h) describes a list of functions that should be used when configuration options are required for a command being tested. Options are set in a `StringList` which must be defined and passed to the `HRN_CFG_LOAD()` macro with the command. For example, the following will set up a test to run `pgbunker --repo-path=test/test-0/repo info` command on multiple repositories, one of which is encrypted:
 ```
 StringList *argList = strLstNew();                                  // Create an empty string list
 hrnCfgArgRawZ(argList, cfgOptRepoPath, TEST_PATH "/repo");          // Add the --repo-path option
@@ -423,7 +423,7 @@ HRN_CFG_LOAD(cfgCmdInfo, argList);                                  // Load the 
 
 #### Storing a file
 
-Sometimes it is desirable to store or manipulate files before or during a test and then confirm the contents. The [harnessStorage.h](https://github.com/pgbackrest/pgbackrest/blob/main/test/src/common/harnessStorage.h) file contains macros (e.g. `HRN_STORAGE_PUT` and `TEST_STORAGE_GET`) for doing this. In addition, `HRN_INFO_PUT` is convenient for writing out info files (archive.info, backup.info, backup.manifest) since it will automatically add header and checksum information.
+Sometimes it is desirable to store or manipulate files before or during a test and then confirm the contents. The [harnessStorage.h](https://github.com/pgbunker/pgbunker/blob/main/test/src/common/harnessStorage.h) file contains macros (e.g. `HRN_STORAGE_PUT` and `TEST_STORAGE_GET`) for doing this. In addition, `HRN_INFO_PUT` is convenient for writing out info files (archive.info, backup.info, backup.manifest) since it will automatically add header and checksum information.
 ```
 HRN_STORAGE_PUT_EMPTY(
     storageRepoWrite(), STORAGE_REPO_ARCHIVE "/10-1/000000010000000100000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz");
@@ -431,7 +431,7 @@ HRN_STORAGE_PUT_EMPTY(
 
 #### Testing results
 
-Tests are run and results confirmed via macros that are described in [harnessTest.h](https://github.com/pgbackrest/pgbackrest/blob/main/test/src/common/harnessTest.h). With the exception of TEST_ERROR, the third parameter is a short description of the test. Some of the more common macros are:
+Tests are run and results confirmed via macros that are described in [harnessTest.h](https://github.com/pgbunker/pgbunker/blob/main/test/src/common/harnessTest.h). With the exception of TEST_ERROR, the third parameter is a short description of the test. Some of the more common macros are:
 
 - `TEST_RESULT_STR` - Test the actual value of the string returned by the function.
 
@@ -457,7 +457,7 @@ In the above, `Pxx` indicates the process (P) and the process number (xx), e.g. 
 
 #### Testing using child process
 
-Sometimes it is useful to use a child process for testing. Below is a simple example. See [harnessFork.h](https://github.com/pgbackrest/pgbackrest/blob/main/test/src/common/harnessFork.h) for more details.
+Sometimes it is useful to use a child process for testing. Below is a simple example. See [harnessFork.h](https://github.com/pgbunker/pgbunker/blob/main/test/src/common/harnessFork.h) for more details.
 ```
 HRN_FORK_BEGIN()
 {
@@ -501,7 +501,7 @@ HRN_FORK_END();
 
 #### Testing using a shim
 
-A PostgreSQL libpq shim is provided to simulate interactions with PostgreSQL. Below is a simple example. See [harnessPq.h](https://github.com/pgbackrest/pgbackrest/blob/main/test/src/common/harnessPq.h) for more details.
+A PostgreSQL libpq shim is provided to simulate interactions with PostgreSQL. Below is a simple example. See [harnessPq.h](https://github.com/pgbunker/pgbunker/blob/main/test/src/common/harnessPq.h) for more details.
 ```
 // Set up two standbys but no primary
 HRN_PQ_SCRIPT_SET(
@@ -521,11 +521,11 @@ TEST_ERROR(cmdCheck(), ConfigError, "primary database not found\nHINT: check ind
 
 Unit tests are run for all files that are listed in `define.yaml` and a coverage report generated for each file listed under the tag `coverage:`. Note that some files are listed in multiple `coverage:` sections for a module; in this case, each test for the file being modified should be specified for the module in which the file exists (e.g. `--module=storage --test=posix --test=gcs`, etc.) or, alternatively, simply run the module without the `--test` option. It is recommended that a `--vm` be specified since running the same test for multiple vms is unnecessary for coverage. The following example would run the test set from the **define.yaml** section detailed above.
 ```
-pgbackrest/test/test.pl --vm-out --module=command --test=check --vm=u22
+pgbunker/test/test.pl --vm-out --module=command --test=check --vm=u22
 ```
 > **NOTE:** Not all systems perform at the same speed, so if a test is timing out, try rerunning with another vm.
 
-A coverage report will be generated and written to the local file system under the pgBackRest repository in `test/result/coverage.html`.
+A coverage report will be generated and written to the local file system under the pgBunker repository in `test/result/coverage.html`.
 
 If 100 percent code coverage has not been achieved, an error message will be displayed, for example: `ERROR: [125]: c module command/check/check is not fully covered`
 
@@ -533,7 +533,7 @@ If 100 percent code coverage has not been achieved, an error message will be dis
 
 Sometimes it is useful to look at files that were generated during the test. The default for running any test is that, at the start/end of the test, the test harness will clean up all files and directories created. To override this behavior, a single test run must be specified and the option `--no-cleanup` provided. Again, continuing with the check command, from **define.yaml** above, there are four tests. Below, test one will be run and nothing will be cleaned up so that the files and directories in `test/test-0` can be inspected.
 ```
-pgbackrest/test/test.pl --vm-out --module=command --test=check --run=1 --no-cleanup
+pgbunker/test/test.pl --vm-out --module=command --test=check --run=1 --no-cleanup
 ```
 
 ### Understanding Test Output
@@ -570,7 +570,7 @@ These files are discussed in the following sections along with how to verify the
 
 There are detailed comment blocks above each section that explain the rules for defining commands and options. Regarding options, there are two types: 1) command line only, and 2) configuration file. With the exception of secrets, all configuration file options can be passed on the command line. To configure an option for the configuration file, the `section:` key must be present.
 
-The `option:` section is broken into sub-sections by a simple comment divider (e.g. `# Repository options`) under which the options are organized alphabetically by option name. To better explain this section, two hypothetical examples will be discussed. For more details, see [config.yaml](https://github.com/pgbackrest/pgbackrest/blob/main/src/build/config/config.yaml).
+The `option:` section is broken into sub-sections by a simple comment divider (e.g. `# Repository options`) under which the options are organized alphabetically by option name. To better explain this section, two hypothetical examples will be discussed. For more details, see [config.yaml](https://github.com/pgbunker/pgbunker/blob/main/src/build/config/config.yaml).
 
 #### EXAMPLE 1 hypothetical command line only option
 ```
@@ -657,30 +657,30 @@ To add an option, add the following to the `<option-list>` section; if it does n
 
 It is important to run the `help` command unit test after adding an option in case a change is required:
 ```
-pgbackrest/test/test.pl --module=command --test=help --vm-out
+pgbunker/test/test.pl --module=command --test=help --vm-out
 ```
-To verify the `help` command output, build the pgBackRest executable:
+To verify the `help` command output, build the pgBunker executable:
 ```
-pgbackrest/test/test.pl --build-only
+pgbunker/test/test.pl --build-only
 ```
-Use the pgBackRest executable to test the help output:
+Use the pgBunker executable to test the help output:
 ```
-test/bin/none/pgbackrest help backup repo-type
+test/bin/none/pgbunker help backup repo-type
 ```
 
 ### Testing the documentation
 
 To quickly view the HTML documentation, the `--no-exe` option can be passed to the documentation generator in order to bypass executing the code elements:
 ```
-pgbackrest/doc/doc.pl --out=html --no-exe
+pgbunker/doc/doc.pl --out=html --no-exe
 ```
 The generated HTML files will be placed in the `doc/output/html` directory where they can be viewed locally in a browser.
 
-If Docker is installed, it will be used by the documentation generator to execute the code elements while building the documentation, therefore, the `--no-exe` should be omitted, (i.e. `pgbackrest/doc/doc.pl --output=html`). `--no-cache` may be used to force a full build even when no code elements have changed since the last build. `--pre` will reuse the container definitions from the prior build and saves time during development.
+If Docker is installed, it will be used by the documentation generator to execute the code elements while building the documentation, therefore, the `--no-exe` should be omitted, (i.e. `pgbunker/doc/doc.pl --output=html`). `--no-cache` may be used to force a full build even when no code elements have changed since the last build. `--pre` will reuse the container definitions from the prior build and saves time during development.
 
 The containers created for documentation builds can be useful for manually testing or trying out new code or features. The following demonstrates building through just the `quickstart` section of the `user-guide` without encryption.
 ```
-pgbackrest/doc/doc.pl --out=html --include=user-guide --require=/quickstart --var=encrypt=n --no-cache --pre
+pgbunker/doc/doc.pl --out=html --include=user-guide --require=/quickstart --var=encrypt=n --no-cache --pre
 ```
 The resulting Docker containers can be listed with `docker ps` and the container can be entered with `docker exec doc-pg-primary bash`. Additionally, the `-u` option can be added for entering the container as a specific user (e.g. `postgres`).
 
@@ -688,7 +688,7 @@ The resulting Docker containers can be listed with `docker ps` and the container
 
 Before submitting a Pull Request:
 
-- Does it meet the [coding standards](https://github.com/pgbackrest/pgbackrest/blob/main/CODING.md)?
+- Does it meet the [coding standards](https://github.com/pgbunker/pgbunker/blob/main/CODING.md)?
 
 - Have [Unit Tests](#writing-a-unit-test) been written and [run](#running-a-unit-test) with 100% coverage?
 
@@ -702,7 +702,7 @@ When submitting a Pull Request:
 
 - Write a detailed comment to describe the purpose of your submission and any issue(s), if any, it is resolving; a link to the GitHub issue is also helpful.
 
-- Select the `integration` branch as the base for your PR, do not select `main` nor any other branch.
+- Select the `main` branch as the base for your PR.
 
 After submitting a Pull Request:
 
@@ -710,4 +710,4 @@ After submitting a Pull Request:
 
 - Respond to any issues (conversations) in GitHub but do not resolve the conversation; the reviewer is responsible for ensuring the issue raised has been resolved and marking the conversation resolved. It is helpful to supply the commit in your reply if one was submitted to fix the issue.
 
-Lastly, thank you for contributing to pgBackRest!
+Lastly, thank you for contributing to pgBunker!

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ duplicates.
 
 ### Parallel Backup & Restore
 
-Compression is usually the bottleneck during backup operations so pgBackRest solves this problem with parallel processing and more efficient compression algorithms such as lz4 and zstd.
+Compression is usually the bottleneck during backup operations so pgBunker solves this problem with parallel processing and more efficient compression algorithms such as lz4 and zstd.
 
 ### Local or Remote Operation
 
-A custom protocol allows pgBackRest to backup, restore, and archive locally or remotely via TLS/SSH with minimal configuration. An interface to query PostgreSQL is also provided via the protocol layer so that remote access to PostgreSQL is never required, which enhances security.
+A custom protocol allows pgBunker to backup, restore, and archive locally or remotely via TLS/SSH with minimal configuration. An interface to query PostgreSQL is also provided via the protocol layer so that remote access to PostgreSQL is never required, which enhances security.
 
 ### Multiple Repositories
 
@@ -42,7 +42,7 @@ Multiple repositories allow, for example, a local repository with minimal retent
 
 ### Full, Differential, & Incremental Backups (at File or Block Level)
 
-Full, differential, and incremental backups are supported. pgBackRest is not susceptible to the time resolution issues of rsync, making differential and incremental backups safe without the requirement to checksum each file. Block-level backups save space by only copying the parts of files that have changed.
+Full, differential, and incremental backups are supported. pgBunker is not susceptible to the time resolution issues of rsync, making differential and incremental backups safe without the requirement to checksum each file. Block-level backups save space by only copying the parts of files that have changed.
 
 ### Backup Rotation & Archive Expiration
 
@@ -58,7 +58,7 @@ All operations utilize file and directory level fsync to ensure durability.
 
 ### Page Checksums
 
-If page checksums are enabled pgBackRest will validate the checksums for every file that is copied during a backup. All page checksums are validated during a full backup and checksums in files that have changed are validated during differential and incremental backups.
+If page checksums are enabled pgBunker will validate the checksums for every file that is copied during a backup. All page checksums are validated during a full backup and checksums in files that have changed are validated during differential and incremental backups.
 
 Validation failures do not stop the backup process, but warnings with details of exactly which pages have failed validation are output to the console and file log.
 
@@ -96,19 +96,19 @@ File and directory links are supported for any file or directory in the PostgreS
 
 ### S3, Azure, and GCS Compatible Object Store Support
 
-pgBackRest repositories can be located in S3, Azure, and GCS compatible object stores to allow for virtually unlimited capacity and retention.
+pgBunker repositories can be located in S3, Azure, and GCS compatible object stores to allow for virtually unlimited capacity and retention.
 
 ### Encryption
 
-pgBackRest can encrypt the repository to secure backups wherever they are stored.
+pgBunker can encrypt the repository to secure backups wherever they are stored.
 
 ### Compatibility with ten versions of PostgreSQL
 
-pgBackRest includes support for ten versions of PostgreSQL, the five supported versions and the last five EOL versions. This allows ample time to upgrade to a supported version.
+pgBunker includes support for ten versions of PostgreSQL, the five supported versions and the last five EOL versions. This allows ample time to upgrade to a supported version.
 
 ## Getting Started
 
-pgBackRest strives to be easy to configure and operate:
+pgBunker strives to be easy to configure and operate:
 
 - [User guides](https://pgbunker.github.io/website/user-guide-index.html) for various operating systems and PostgreSQL versions.
 
@@ -118,11 +118,11 @@ pgBackRest strives to be easy to configure and operate:
 
 ## Contributions
 
-Contributions to pgBackRest are always welcome! Please see our [Contributing Guidelines](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md) for details on how to contribute features, improvements or issues.
+Contributions to pgBunker are always welcome! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to contribute features, improvements or issues.
 
 ## Support
 
-pgBackRest is completely free and open source under the [MIT](https://github.com/pgbackrest/pgbackrest/blob/main/LICENSE) license. You may use it for personal or commercial purposes without any restrictions whatsoever. Bug reports are taken very seriously and will be addressed as quickly as possible. Please report bugs [here]({[github-url-base}]/issues).
+pgBunker is completely free and open source under the [MIT](LICENSE) license. You may use it for personal or commercial purposes without any restrictions whatsoever. Bug reports are taken very seriously and will be addressed as quickly as possible. Please report bugs [here](https://github.com/pgbunker/pgbunker/issues).
 
 Creating a robust disaster recovery policy with proper replication and backup strategies can be a very complex and daunting task. You may find that you need help during the architecture phase and ongoing support to ensure that your enterprise continues running smoothly. There are a variety of PostgreSQL support companies that can provide this service.
 


### PR DESCRIPTION
These three files were left mostly unchanged at fork time. They referred to the project as pgBackRest, linked to upstream issues / license / contributing guidelines, and used the upstream pgbackrest-dev / pgbackrest/test/test.pl naming convention which has already been switched over in doc/RELEASE.md and exe.cache.

  - README.md: rebrand the Features / Getting Started / Contributions / Support sections to pgBunker; point Contributing Guidelines and LICENSE links at the in-repo files; replace the unrendered {[github-url-base]} variable with a literal pgbunker URL. Upstream / historical references (line 5, 7, 11, 13, 15, 22-23) are deliberately kept. Sponsorship section is left untouched.

  - CONTRIBUTING.md: rebrand to pgBunker, point all self-links at pgbunker/pgbunker on GitHub, switch pgbackrest-dev host alias and pgbackrest/test|doc paths to pgbunker-* (matching exe.cache and RELEASE.md), update example bin path test/bin/none/pgbunker, and correct the PR base branch from `integration` to `main`.

  - .github/ISSUE_TEMPLATE.md: rebrand prompts to pgBunker; ask for pgbunker.conf with a fallback note for migrated installs; update log path to /var/log/pgbunker (the current default per src/build/config/config.yaml).

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
