### PR TITLE
Rebrand stale pgBackRest references in dev/CI infrastructure.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           # harness issue is debugged)
           - param: test --vm=rh8 --param=module=integration
 
-          # NOTE: pgBackRest's upstream 'doc --vm=u22' / 'doc --vm=rh8' jobs are removed for
+          # NOTE: upstream pgBackRest's 'doc --vm=u22' / 'doc --vm=rh8' jobs are removed for
           # now. They run release.pl which validates that every <release-item> in
           # doc/xml/release.xml maps to an upstream-style commit subject. pgBunker's
           # commit history doesn't follow that convention, and patching the validator to
@@ -66,17 +66,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          path: pgbackrest
+          path: pgbunker
 
       - name: Run Test
-        run: cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbackrest/test/ci.pl ${{matrix.param}} --param=build-max=2
+        run: cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbunker/test/ci.pl ${{matrix.param}} --param=build-max=2
 
       # Output the coverage report on failure in case the failure was caused by lack of coverage. This is not ideal since the report
       # needs to be copied from the log output into an HTML file where it can be viewed, but better than nothing.
       - name: Coverage Report
         if: failure()
         run: |
-          cat ${GITHUB_WORKSPACE?}/pgbackrest/test/result/coverage/coverage.html
+          cat ${GITHUB_WORKSPACE?}/pgbunker/test/result/coverage/coverage.html
 
   # Unit tests on aarch64 with valgrind
   aarch64:
@@ -86,10 +86,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          path: pgbackrest
+          path: pgbunker
 
       - name: Run Test
-        run: cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbackrest/test/ci.pl test --vm=u22 --param=c-only --param=no-coverage --param=no-back-trace --param=build-max=2
+        run: cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbunker/test/ci.pl test --vm=u22 --param=c-only --param=no-coverage --param=no-back-trace --param=build-max=2
 
   # Basic tests on other architectures using emulation. The emulation is so slow that running all the unit tests would be too
   # expensive, but this at least shows that the build works and some of the more complex tests run. In particular, it is good to
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          path: pgbackrest
+          path: pgbunker
 
       - name: Install
         run: |
@@ -119,12 +119,12 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Build VM
-        run: ${GITHUB_WORKSPACE?}/pgbackrest/test/test.pl --vm-build --vm=u22 --vm-arch=${{matrix.arch}}
+        run: ${GITHUB_WORKSPACE?}/pgbunker/test/test.pl --vm-build --vm=u22 --vm-arch=${{matrix.arch}}
 
       - name: Run Test
         run: |
-          ${GITHUB_WORKSPACE?}/pgbackrest/test/test.pl --vm=u22 --vm-arch=${{matrix.arch}} --no-valgrind --no-coverage --no-optimize --build-max=2 --module=command --test=backup
-          ${GITHUB_WORKSPACE?}/pgbackrest/test/test.pl --vm=u22 --vm-arch=${{matrix.arch}} --no-valgrind --no-coverage --no-optimize --build-max=2 --module=postgres --test=interface
+          ${GITHUB_WORKSPACE?}/pgbunker/test/test.pl --vm=u22 --vm-arch=${{matrix.arch}} --no-valgrind --no-coverage --no-optimize --build-max=2 --module=command --test=backup
+          ${GITHUB_WORKSPACE?}/pgbunker/test/test.pl --vm=u22 --vm-arch=${{matrix.arch}} --no-valgrind --no-coverage --no-optimize --build-max=2 --module=postgres --test=interface
 
   # Selected unit tests on MacOS
   macos:
@@ -185,7 +185,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          path: pgbackrest
+          path: pgbunker
 
       - name: Install
         run: |
@@ -194,12 +194,12 @@ jobs:
 
       - name: Build
         run: |
-          meson setup --unity=on -Dwerror=true build ${GITHUB_WORKSPACE?}/pgbackrest
+          meson setup --unity=on -Dwerror=true build ${GITHUB_WORKSPACE?}/pgbunker
           ninja -vC build
 
       - name: Check
         run: |
-          diff ${GITHUB_WORKSPACE?}/pgbackrest/.github/workflows/symbol.out <(nm -gj --defined-only build/src/pgbunker)
+          diff ${GITHUB_WORKSPACE?}/pgbunker/.github/workflows/symbol.out <(nm -gj --defined-only build/src/pgbunker)
 
   # Check that code is correctly formatted
   code-format:
@@ -209,8 +209,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          path: pgbackrest
+          path: pgbunker
 
       - name: Check
         run: |
-          cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbackrest/test/ci.pl test --param=code-format-check
+          cd ${HOME?} && ${GITHUB_WORKSPACE?}/pgbunker/test/ci.pl test --param=code-format-check

--- a/CODING.md
+++ b/CODING.md
@@ -1,10 +1,10 @@
-# pgBackRest <br/> Coding Standards
+# pgBunker <br/> Coding Standards
 
 ## Formatting with uncrustify
 
-pgBackRest uses uncrustify to check/update the code formatting. If the `code-format` test fails in CI then reformat the code:
+pgBunker uses uncrustify to check/update the code formatting. If the `code-format` test fails in CI then reformat the code:
 ```
-pgbackrest/test/test.pl --code-format
+pgbunker/test/test.pl --code-format
 ```
 Also review the standards in the following sections below. Some standards require further explanation and others are not enforced by uncrustify.
 
@@ -268,11 +268,11 @@ Continuation characters should be aligned at column 132 (unlike the example abov
 
 This function can be called without variable parameters:
 ```c
-storagePathCreateP(storageLocal(), "/tmp/pgbackrest");
+storagePathCreateP(storageLocal(), "/tmp/pgbunker");
 ```
 Or with variable parameters:
 ```c
-storagePathCreateP(storageLocal(), "/tmp/pgbackrest", .errorOnExists = true, .mode = 0777);
+storagePathCreateP(storageLocal(), "/tmp/pgbunker", .errorOnExists = true, .mode = 0777);
 ```
 If the majority of functions in a module or object are variadic it is best to provide macros for all functions even if they do not have variable parameters. Do not use the base function when variadic macros exist.
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,7 +8,7 @@ if get_option('unity') == 'on'
     configuration.set('VR_EXTERN_DECLARE', 'static', description: 'Variable declaration is static for unity build')
     configuration.set('VR_EXTERN_DEFINE', 'static', description: 'Variable definition is static for unity build')
 
-    # Add args to builds to prevent non-pgbackrest binaries failing due to unused functions
+    # Add args to builds to prevent non-pgbunker binaries failing due to unused functions
     arg_unity += '-Wno-unused-function'
 else
     configuration.set(
@@ -116,9 +116,9 @@ subdir('command/help')
 subdir('postgres')
 
 ####################################################################################################################################
-# pgBackRest target
+# pgBunker target
 ####################################################################################################################################
-src_pgbackrest = [
+src_pgbunker = [
     'command/annotate/annotate.c',
     'command/archive/common.c',
     'command/archive/find.c',
@@ -274,7 +274,7 @@ src_pgbackrest = [
 executable(
     'pgbunker',
     src_common,
-    src_pgbackrest,
+    src_pgbunker,
     help_auto_c_inc,
     interface_auto_c_inc,
     dependencies: [


### PR DESCRIPTION
Continues the rename pass from #24, this time covering the contributor-facing coding standards doc, the GitHub Actions workflow, and the leftover meson target name.

  - CODING.md: rebrand title and intro to pgBunker, switch test runner path to pgbunker/test/test.pl, and update the /tmp/pgbackrest example paths in the storage API examples to /tmp/pgbunker.

  - .github/workflows/test.yml: rename the actions/checkout target directory from pgbackrest -> pgbunker for all five jobs that use it (test, aarch64, arch, unity, code-format), and update every ${GITHUB_WORKSPACE}/pgbackrest reference in the run scripts to match. The unity job's nm output diff already targets build/src/pgbunker; this only fixes the source-tree path used to invoke meson and ci.pl. The L57 NOTE keeps "upstream pgBackRest" as a deliberate reference to the upstream project.

  - src/meson.build: rename the meson variable src_pgbackrest -> src_pgbunker (only used within this file), update the surrounding "pgBackRest target" header comment, and fix the unity-build comment that mentioned non-pgbackrest binaries.

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
