### PR TITLE
Rebrand stale pgBackRest mentions in code comments and test fixture

### DIFF
--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -926,8 +926,8 @@ backupResumeFind(const Manifest *const manifest, const String *const cipherPassB
                             {
                                 const ManifestData *manifestResumeData = manifestData(manifestResume);
 
-                                // Check pgBackRest version. This allows the resume implementation to be changed with each version
-                                // of pgBackRest at the expense of users losing a resumable back after an upgrade, which seems worth
+                                // Check pgBunker version. This allows the resume implementation to be changed with each version
+                                // of pgBunker at the expense of users losing a resumable back after an upgrade, which seems worth
                                 // the cost.
                                 if (!strEq(manifestResumeData->backrestVersion, manifestData(manifest)->backrestVersion))
                                 {

--- a/src/command/verify/file.h
+++ b/src/command/verify/file.h
@@ -22,7 +22,7 @@ typedef enum
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/
-// Verify a file in the pgBackRest repository
+// Verify a file in the pgBunker repository
 FN_EXTERN VerifyResult verifyFile(
     const String *filePathName, uint64_t offset, const Variant *limit, CompressType compressType, const Buffer *fileChecksum,
     uint64_t fileSize, const String *cipherPass);

--- a/src/common/crypto/cipherBlock.c
+++ b/src/common/crypto/cipherBlock.c
@@ -401,7 +401,7 @@ cipherBlockNew(const CipherMode mode, const CipherType cipherType, const Buffer 
     cryptoInit();
 
     // Lookup cipher by name. This means the ciphers passed in must exactly match a name expected by OpenSSL. This is a good thing
-    // since the name required by the openssl command-line tool will match what is used by pgBackRest.
+    // since the name required by the openssl command-line tool will match what is used by pgBunker.
     char *const cipherTypeZ = zNewStrId(cipherType);
     const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipherTypeZ);
 

--- a/src/db/db.c
+++ b/src/db/db.c
@@ -290,7 +290,7 @@ dbOpen(Db *const this)
         this->pub.pgVersion = (unsigned int)pckReadI32P(read) / 100 * 100;
 
         // Store the data directory that PostgreSQL is running in, the archive mode, and archive command. These can be compared to
-        // the configured pgBackRest directory, and archive settings checked for validity, when validating the configuration.
+        // the configured pgBunker directory, and archive settings checked for validity, when validating the configuration.
         // Also store the checkpoint timeout to warn in case a backup is requested without using the start-fast option.
         MEM_CONTEXT_BEGIN(this->pub.memContext)
         {

--- a/src/info/info.c
+++ b/src/info/info.c
@@ -186,7 +186,7 @@ infoNewLoad(IoRead *const read, InfoLoadNewCallback *const callbackFunction, voi
                                         varUInt64(jsonToVar(value->value)));
                                 }
                             }
-                            // Store pgBackRest version
+                            // Store pgBunker version
                             else if (strEqZ(value->key, INFO_KEY_VERSION))
                             {
                                 MEM_CONTEXT_OBJ_BEGIN(this)

--- a/src/info/info.h
+++ b/src/info/info.h
@@ -48,7 +48,7 @@ Getters/Setters
 ***********************************************************************************************************************************/
 typedef struct InfoPub
 {
-    const String *backrestVersion;                                  // pgBackRest version
+    const String *backrestVersion;                                  // pgBunker version
     const String *cipherPass;                                       // Cipher passphrase if set
 } InfoPub;
 
@@ -61,7 +61,7 @@ infoCipherPass(const Info *const this)
 
 FN_EXTERN void infoCipherPassSet(Info *this, const String *cipherPass);
 
-// pgBackRest version
+// pgBunker version
 FN_INLINE_ALWAYS const String *
 infoBackrestVersion(const Info *const this)
 {

--- a/src/info/manifest/manifest.h
+++ b/src/info/manifest/manifest.h
@@ -50,7 +50,7 @@ Manifest data
 ***********************************************************************************************************************************/
 typedef struct ManifestData
 {
-    const String *backrestVersion;                                  // pgBackRest version
+    const String *backrestVersion;                                  // pgBunker version
 
     const String *backupLabel;                                      // Backup label (unique identifier for the backup)
     const String *backupLabelPrior;                                 // Backup label for backup this diff/incr is based on

--- a/src/postgres/client.h
+++ b/src/postgres/client.h
@@ -2,7 +2,7 @@
 PostgreSQL Client
 
 Connect to a PostgreSQL database and run queries. This is not intended to be a general purpose client but is suitable for
-pgBackRest's limited needs. In particular, data type support is limited to text, int, and bool types so it may be necessary to add
+pgBunker's limited needs. In particular, data type support is limited to text, int, and bool types so it may be necessary to add
 casts to queries to output one of these types.
 ***********************************************************************************************************************************/
 #ifndef POSTGRES_QUERY_H

--- a/src/postgres/interface/version.intern.h
+++ b/src/postgres/interface/version.intern.h
@@ -11,7 +11,7 @@ These macros should be kept as simple as possible, with most of the logic contai
 
 /***********************************************************************************************************************************
 Determine if the supplied pg_control is for this version of PostgreSQL. When CATALOG_VERSION_NO_MAX is defined then the catalog will
-be accepted as a range that lasts until the end of the encoded year. This allows pgBackRest to work with PostgreSQL during the
+be accepted as a range that lasts until the end of the encoded year. This allows pgBunker to work with PostgreSQL during the
 alpha/beta/rc period without needing to be updated, unless of course the actual interface changes.
 ***********************************************************************************************************************************/
 #ifdef CATALOG_VERSION_NO_MAX

--- a/test/src/build/help/help.xml
+++ b/test/src/build/help/help.xml
@@ -159,7 +159,7 @@
                         <p>Path to the original code repository or a copy.</p>
                     </text>
 
-                    <example>/path/to/pgbackrest</example>
+                    <example>/path/to/pgbunker</example>
                 </option>
 
                 <option id="scale">
@@ -239,7 +239,7 @@
                 <summary>Get help.</summary>
 
                 <text>
-                    <p>Three levels of help are provided. If no command is specified then general help will be displayed. If a command is specified (e.g. <cmd>test-pgbackrest help test</cmd>) then a full description of the command will be displayed along with a list of valid options. If an option is specified in addition to a command (e.g. <cmd>pgbackrest help test vm</cmd>) then a full description of the option as it applies to the command will be displayed.</p>
+                    <p>Three levels of help are provided. If no command is specified then general help will be displayed. If a command is specified (e.g. <cmd>test-pgbunker help test</cmd>) then a full description of the command will be displayed along with a list of valid options. If an option is specified in addition to a command (e.g. <cmd>pgbunker help test vm</cmd>) then a full description of the option as it applies to the command will be displayed.</p>
                 </text>
 
                 <option-list>
@@ -272,7 +272,7 @@
                 <summary>Run a test.</summary>
 
                 <text>
-                    <p>By default tests expect to run with the code repository in a subpath named <path>pgbackrest</path>. Tests will be run in a subpath named <path>test</path>.</p>
+                    <p>By default tests expect to run with the code repository in a subpath named <path>pgbunker</path>. Tests will be run in a subpath named <path>test</path>.</p>
 
                     <p>A test can be run by using the module option, e.g. <br-option>--module=common/error</br-option>.</p>
                 </text>


### PR DESCRIPTION
## Summary
  - Rebrand 11 stale `pgBackRest` mentions in C-source comments to `pgBunker`: backup version check
  (`backup.c`), verify-file header (`verify/file.h`), openssl cipher convention (`cipherBlock.c`),
  configured directory (`db.c`), on-disk `backrestVersion` field comments (`info.c`, `info.h`,
  `manifest/manifest.h`), postgres client doc (`postgres/client.h`), catalog-version range note
  (`postgres/interface/version.intern.h`).
  - Rename 3 example strings in `test/src/build/help/help.xml` (`/path/to/pgbackrest` →
  `/path/to/pgbunker`, `test-pgbackrest help test` → `test-pgbunker help test`, `pgbackrest help test vm` →
   `pgbunker help test vm`, `<path>pgbackrest</path>` → `<path>pgbunker</path>`) so the test binary's
  generated help matches its actual name `test-pgbunker`.
  - 10 files, 14 insertions / 14 deletions. Comment-only + 1 test fixture; zero impact on compiled binary
  artifacts.

  ## Deliberately not touched
  - `PGBACKREST_ENV` / `PGBACKREST_ENV_SIZE` macros and callers (`config/parse.h`,
  `command/check/report.c`, etc.) — legacy env-var prefix is still the canonical entry point.
  - `PGBACKREST_CONFIG_ORIG_PATH_FILE` and surrounding `parse.c` comments — legacy config-file fallback.
  - `infoPg.c`/`infoPg.h` "older pgBackRest versions expect them" — historical compat notes.
  - Vendored upstream code (`postgres/interface/static.vendor.h`, `version.vendor.h`).
  - `*.pgbackrest.org` test hostnames in `ioTlsTest.c` + matching SANs in
  `test/certificate/pgbunker-test-server.cnf` — coordinated change, requires cert regen, deferred.
  - Historical release-note XML under `doc/xml/release/2010s/`.
  - The on-disk struct field name `backrestVersion` itself (kept for repository format compatibility); only
   the comments describing the field were updated.

  ## Test plan
  - [x] CI 14/14 green on `code-comments-rebrand-ci` (run
  [25097965130](https://github.com/pgbunker/pgbunker/actions/runs/25097965130))
  - [x] `git grep -i pgbackrest` on the 10 touched files returns clean
  - [x] No test asserts on the renamed help-fixture strings (verified via `git grep` for the old literals)