### PR TITLE
Create lock directory with mode 0770 to match the documented behavior.

### DIFF
--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -317,7 +317,7 @@
                         <summary>Use a neutral umask.</summary>
 
                         <text>
-                            <p>Sets the umask to 0000 so modes in the repository are created in a sensible way. The default directory mode is 0750 and default file mode is 0640. The lock and log directories set the directory and file mode to 0770 and 0660 respectively.</p>
+                            <p>Sets the umask to 0000 so modes in the repository are created in a sensible way. The default directory mode is 0750 and default file mode is 0640. The lock directory is created with mode 0770 so that processes running as different OS users in the same group can share a lock directory.</p>
 
                             <p>To use the executing user's umask instead specify <setting>neutral-umask=n</setting> in the config file or <setting>--no-neutral-umask</setting> on the command line.</p>
                         </text>

--- a/src/common/lock.c
+++ b/src/common/lock.c
@@ -185,10 +185,11 @@ lockAcquire(const String *const lockFileName, const LockAcquireParam param)
                 // Save the error for reporting outside the loop
                 errNo = errno;
 
-                // If the path does not exist then create it
+                // If the path does not exist then create it. Use mode 0770 (rather than the storage default 0750) so processes that
+                // run as different OS users in the same group can share a lock directory, matching the documented behavior.
                 if (errNo == ENOENT)
                 {
-                    storagePathCreateP(storagePosixNewP(FSLASH_STR, .write = true), strPath(lockFilePath));
+                    storagePathCreateP(storagePosixNewP(FSLASH_STR, .write = true), strPath(lockFilePath), .mode = 0770);
                     retry = true;
                 }
             }

--- a/test/src/module/common/lockTest.c
+++ b/test/src/module/common/lockTest.c
@@ -103,6 +103,16 @@ testRun(void)
             strZ(noPermLock), strZ(noPermLock));
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("lock dir is auto-created with mode 0770 (issue #9)");
+
+        const String *const lockFileAutoDirName = STRDEF("auto-lock-dir/test" LOCK_FILE_EXT);
+        StorageInfo lockPathInfo = {0};
+
+        TEST_RESULT_BOOL(lockAcquireP(lockFileAutoDirName), true, "acquire lock under non-existent subpath");
+        TEST_ASSIGN(lockPathInfo, storageInfoP(storageTest, STRDEF("auto-lock-dir")), "stat created lock dir");
+        TEST_RESULT_INT(lockPathInfo.mode, 0770, "lock dir mode is 0770");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("acquire file lock on the same exec-id");
 
         const String *const lockFileExecName = STRDEF("sub/exec" LOCK_FILE_EXT);


### PR DESCRIPTION
pgbunker/pgbunker#9 (re-filed from upstream pgBackRest #1497).

The neutral-umask documentation has long stated that the lock directory is created with mode 0770 so that processes running as different OS users in the same group can share a lock directory. The actual code silently used the generic storage default of 0750, which broke that sharing scenario for users who have, for example, multiple PostgreSQL clusters owned by different OS users in a shared 'postgres' group on the same host.

Upstream maintainer confirmed in the original issue thread that changing the code to match the documented 0770 behavior was the preferred fix, but no upstream PR landed before EOL. This commit applies that fix.

Changes:

  - src/common/lock.c: pass .mode = 0770 when auto-creating the lock directory in lockAcquire(). The lock file itself still uses the storage default (0640).

  - src/build/help/help.xml: rewrite the neutral-umask description. The old text claimed "lock and log directories set the directory and file mode to 0770 and 0660 respectively", which was wrong on multiple counts (lock dir was actually 0750, lock file is 0640 not 0660, and the log directory is no longer auto-created at all). The new text only documents the lock directory's 0770 mode, which is now accurate.

  - test/src/module/common/lockTest.c: add a regression test that acquires a lock under a non-existent subpath, then stat()s the auto-created directory and asserts mode == 0770. Test harness runs with umask(0) (test/test.pl), so the requested mode lands on disk unmodified.


