### PR TITLE
Async archive-push checks queue size against the ready list, not the process list.

### DIFF
--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -548,8 +548,12 @@ cmdArchivePushAsync(void)
                 strLstSize(jobData.walFileList) == 1 ?
                     "" : zNewFmt("...%s", strZ(strLstGet(jobData.walFileList, strLstSize(jobData.walFileList) - 1))));
 
-            // Drop files if queue max has been exceeded
-            if (cfgOptionTest(cfgOptArchivePushQueueMax) && archivePushDrop(jobData.walPath, jobData.walFileList))
+            // Drop files if queue max has been exceeded. Use the full ready list (not the process list, which has had .ok files
+            // filtered out) so that WAL files we have already pushed to the repo - but which PostgreSQL has not yet acknowledged
+            // because the archiver is stuck on an earlier failing file - still count toward the queue. Without this, a single
+            // stuck WAL hides an arbitrarily large pg_wal backlog from the queue-max check, since subsequent WAL files keep
+            // getting .ok'd and disappearing from the process list.
+            if (cfgOptionTest(cfgOptArchivePushQueueMax) && archivePushDrop(jobData.walPath, archivePushReadyList(jobData.walPath)))
             {
                 for (unsigned int walFileIdx = 0; walFileIdx < strLstSize(jobData.walFileList); walFileIdx++)
                 {

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -93,6 +93,36 @@ testRun(void)
 
         // No WAL to be processed
         TEST_RESULT_BOOL(archivePushDrop(STRDEF("pg_wal"), strLstNew()), false, "no WAL to be processed");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("queue check uses ready list, not process list, so .ok'd WAL still counts (issue #6)");
+
+        // After the previous archivePushProcessList run, spool keeps 000003.ok (its .ready is still present) while 000001.ok and
+        // 000004.ok were cleaned up. So readyList = [02, 03, 05, 06] but processList = [02, 05, 06] (000003 filtered out via its
+        // .ok). This models the bug scenario where pgBunker has already pushed a later WAL but PostgreSQL has not yet
+        // acknowledged it because the archiver is stuck on an earlier file - the .ok'd WAL still occupies pg_wal from PG's
+        // perspective.
+        TEST_RESULT_STRLST_Z(
+            archivePushReadyList(STRDEF(TEST_PATH "/db/pg_wal")),
+            "000000010000000100000002\n000000010000000100000003\n000000010000000100000005\n000000010000000100000006\n",
+            "ready list (full backlog from PG's perspective)");
+        TEST_RESULT_STRLST_Z(
+            archivePushProcessList(STRDEF(TEST_PATH "/db/pg_wal")),
+            "000000010000000100000002\n000000010000000100000005\n000000010000000100000006\n",
+            "process list (with 000003 filtered out via its .ok)");
+
+        // Set queue max between 3*walSize (48MB) and 4*walSize (64MB). Process list (3 files) should not trigger a drop, but
+        // ready list (4 files) should - this is exactly the gap that pgbackrest/pgbackrest#2629 reports.
+        StringList *const argListReadyDrop = strLstDup(argList);
+        hrnCfgArgRawFmt(argListReadyDrop, cfgOptArchivePushQueueMax, "%zu", (size_t)50 * 1024 * 1024);
+        HRN_CFG_LOAD(cfgCmdArchivePush, argListReadyDrop, .role = cfgCmdRoleAsync);
+
+        TEST_RESULT_BOOL(
+            archivePushDrop(STRDEF("pg_wal"), archivePushProcessList(STRDEF(TEST_PATH "/db/pg_wal"))), false,
+            "process-list-based check does not drop (would miss the stuck-WAL backlog)");
+        TEST_RESULT_BOOL(
+            archivePushDrop(STRDEF("pg_wal"), archivePushReadyList(STRDEF(TEST_PATH "/db/pg_wal"))), true,
+            "ready-list-based check drops (matches PG's actual backlog)");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
Closes pgbunker/pgbunker#6 (re-filed from upstream pgBackRest #2629).

In async mode the archive-push worker scans archive_status/ for .ready files (PostgreSQL's view of the unacknowledged WAL backlog), filters out any that already have a matching .ok in the spool (WAL we have already pushed to the repo), and processes the remainder. The queue-max check was using that filtered "process list" rather than the full ready list.

That choice is wrong when a single WAL fails repeatedly with ArchiveDuplicateError or similar: pgBunker keeps successfully archiving later WAL segments, each gets a .ok, each is filtered out of the process list. The process list shrinks back to just [stuck-WAL]. Meanwhile PostgreSQL's archiver is blocked retrying the stuck WAL, so PG cannot remove any later WAL from pg_wal even though we have archived them. pg_wal grows without bound until the filesystem fills, but archive-push-queue-max never triggers because the process-list-based size calculation only sees one stuck file.

Upstream confirmed this is a real issue and that the queue-size calculation needs to consider PG's actual backlog (.ready files regardless of whether we have pushed them yet):

> Even though we are able to archive the bulk of the WAL it matters
> little if one is missing and forces WAL unacknowledged by PostgreSQL
> to build up. (...) Really, we need to look at gaps in our .ok files
> relative to Postgres' .ready files in order to calculate the queue
> size.
> -- @dwsteele, pgbackrest/pgbackrest#2629

This commit applies the simplest fix consistent with that direction: the async path's queue-max check now uses archivePushReadyList(), which already returns every .ready file in archive_status/. The drop set is still the process list - we only drop WAL we are about to process - but the *threshold check* now reflects PG's view, so a stuck WAL behind a wall of .ok'd later WAL no longer hides the backlog.

The sync archive-push path (cmdArchivePush) was already calling archivePushReadyList and is not affected.

Changes:

  - src/command/archive/push/push.c (cmdArchivePushAsync): archivePushDrop is now called with archivePushReadyList() instead of jobData.walFileList. Comment expanded to spell out why.

  - test/src/module/command/archivePushTest.c: regression test that exercises the asymmetry. With one .ok'd WAL and three not-yet-.ok'd WAL in archive_status, ready-list-based queue check drops at 50MB threshold (4*16MB > 50MB) while process-list-based check does not (3*16MB < 50MB). The existing test for archivePushProcessList + archivePushDrop continues to pass unchanged.